### PR TITLE
Replace and expand database schema with phpMyAdmin dump

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -1,52 +1,129 @@
--- ========================================
--- Task Manager Database Setup
--- ========================================
+-- phpMyAdmin SQL Dump
+-- version 5.2.1
+-- https://www.phpmyadmin.net/
+--
+-- Host: localhost
+-- Generation Time: Jul 08, 2025 at 08:28 AM
+-- Server version: 8.0.30
+-- PHP Version: 8.1.10
 
--- Step 1: Create the database
-CREATE DATABASE task_manager CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+SET SQL_MODE = "NO_AUTO_VALUE_ON_ZERO";
+START TRANSACTION;
+SET time_zone = "+00:00";
 
--- Step 2: Use the database
-USE task_manager;
 
--- Step 3: Create users table
-CREATE TABLE users (
-    id INT AUTO_INCREMENT PRIMARY KEY,
-    username VARCHAR(50) UNIQUE NOT NULL,
-    email VARCHAR(100) UNIQUE NOT NULL,
-    password VARCHAR(255) NOT NULL,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8mb4 */;
 
--- Step 4: Create tasks table with foreign key
-CREATE TABLE tasks (
-    id INT AUTO_INCREMENT PRIMARY KEY,
-    user_id INT NOT NULL,
-    title VARCHAR(100) NOT NULL,
-    description TEXT,
-    status ENUM('pending', 'completed') DEFAULT 'pending',
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    
-    -- Foreign key constraint
-    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
-);
+--
+-- Database: `task_manager`
+--
 
--- Step 5: Create indexes for better performance
-CREATE INDEX idx_tasks_user_id ON tasks(user_id);
-CREATE INDEX idx_tasks_status ON tasks(status);
-CREATE INDEX idx_tasks_created_at ON tasks(created_at);
+-- --------------------------------------------------------
 
--- Step 6: Insert sample data (optional - for testing)
-INSERT INTO users (username, email, password) VALUES 
-('testuser', 'test@example.com', '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi'),
-('demo', 'demo@example.com', '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi');
+--
+-- Table structure for table `tasks`
+--
 
--- Note: The password hash above is for 'password' - you can login with:
--- Username: testuser, Password: password
--- Username: demo, Password: password
+CREATE TABLE `tasks` (
+  `id` int NOT NULL,
+  `user_id` int NOT NULL,
+  `title` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `description` text COLLATE utf8mb4_unicode_ci,
+  `status` enum('pending','completed') COLLATE utf8mb4_unicode_ci DEFAULT 'pending',
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `due_date` date DEFAULT NULL,
+  `priority` enum('low','medium','high') COLLATE utf8mb4_unicode_ci DEFAULT 'medium',
+  `attachment` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
--- Step 7: Verify the setup
-SELECT 'Database setup completed successfully!' AS status;
-SHOW TABLES;
-DESCRIBE users;
-DESCRIBE tasks;
+--
+-- Dumping data for table `tasks`
+--
+
+INSERT INTO `tasks` (`id`, `user_id`, `title`, `description`, `status`, `created_at`, `updated_at`, `due_date`, `priority`, `attachment`) VALUES
+(1, 3, 'test task', 'optional test task', 'pending', '2025-07-08 06:22:30', '2025-07-08 07:56:47', NULL, 'medium', NULL),
+(2, 3, 'task two', 'second task created', 'completed', '2025-07-08 06:22:53', '2025-07-08 07:56:16', NULL, 'medium', NULL),
+(4, 3, 'task new', 'test that task', 'completed', '2025-07-08 07:03:06', '2025-07-08 07:56:54', NULL, 'medium', NULL),
+(5, 3, 'same task', '', 'completed', '2025-07-08 07:26:00', '2025-07-08 07:56:42', NULL, 'medium', NULL),
+(6, 3, 'new feature test', 'test date picker and priority', 'completed', '2025-07-08 08:12:44', '2025-07-08 08:20:02', '2025-07-15', 'low', NULL),
+(7, 3, 'test file upload', 'test file upload', 'pending', '2025-07-08 08:13:34', '2025-07-08 08:13:34', '2025-07-09', 'high', NULL),
+(8, 3, 'test file upload', 'test file upload', 'pending', '2025-07-08 08:14:07', '2025-07-08 08:14:07', '2025-07-09', 'high', 'uploads/686cd34f113d1_516A3325.jpg');
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `users`
+--
+
+CREATE TABLE `users` (
+  `id` int NOT NULL,
+  `username` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `email` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `password` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+--
+-- Dumping data for table `users`
+--
+
+INSERT INTO `users` (`id`, `username`, `email`, `password`, `created_at`) VALUES
+(1, 'testuser', 'test@example.com', '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', '2025-07-08 04:34:02'),
+(2, 'demo', 'demo@example.com', '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', '2025-07-08 04:34:02'),
+(3, 'kuwest', 'kuwest@gmail.com', '$2y$10$SkrUSuXDXzMEySszH/Lx/eh9CT88/XwR421VIaLXeOVCkvFVmWvFe', '2025-07-08 06:16:19');
+
+--
+-- Indexes for dumped tables
+--
+
+--
+-- Indexes for table `tasks`
+--
+ALTER TABLE `tasks`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `idx_tasks_user_id` (`user_id`),
+  ADD KEY `idx_tasks_status` (`status`),
+  ADD KEY `idx_tasks_created_at` (`created_at`);
+
+--
+-- Indexes for table `users`
+--
+ALTER TABLE `users`
+  ADD PRIMARY KEY (`id`),
+  ADD UNIQUE KEY `username` (`username`),
+  ADD UNIQUE KEY `email` (`email`);
+
+--
+-- AUTO_INCREMENT for dumped tables
+--
+
+--
+-- AUTO_INCREMENT for table `tasks`
+--
+ALTER TABLE `tasks`
+  MODIFY `id` int NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=9;
+
+--
+-- AUTO_INCREMENT for table `users`
+--
+ALTER TABLE `users`
+  MODIFY `id` int NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=4;
+
+--
+-- Constraints for dumped tables
+--
+
+--
+-- Constraints for table `tasks`
+--
+ALTER TABLE `tasks`
+  ADD CONSTRAINT `tasks_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE;
+COMMIT;
+
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;


### PR DESCRIPTION
Replaces the draft SQL schema with a phpMyAdmin-generated dump. Adds new fields to the tasks table (due_date, priority, attachment), includes sample data for both users and tasks, and updates indexes and constraints to match the exported structure.